### PR TITLE
docs: add FilzaSlop research credit and PoC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,14 @@ Do not publish logs, app containers, cookies, account databases, or patch payloa
 
 ## Credits
 
-3105 is developed and designed by [YangJiii](https://x.com/duongduong0908). The project builds on research and community work from FilzaSlop, Pocket Poster/Nugget, CrazyMind90, forcequitOS, Dopamine, and their contributors. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for attribution and upstream links.
+3105 is developed and designed by [YangJiii](https://x.com/duongduong0908).
+
+Special thanks to [`0xjohnny`](https://x.com/0xjohnny) for [FilzaSlop](https://github.com/0xjohnnydev/FilzaSlop) and the ContainerManager research used by 3105:
+
+- [MobileHouseArrest identity-trust bug and MHA-C2 app-container access](https://github.com/0xjohnnydev/MobileHouseArrest-PoC#mobilehousearrest-request)
+- [MobileGestalt class-13 container-access bug](https://github.com/0xjohnnydev/MobileHouseArrest-PoC#mobilegestalt-class-13-request)
+
+The project also builds on work from Pocket Poster/Nugget, CrazyMind90, forcequitOS, Dopamine, and their contributors. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for more attribution and upstream links.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,12 @@ Do not publish logs, app containers, cookies, account databases, or patch payloa
 
 3105 is developed and designed by [YangJiii](https://x.com/duongduong0908).
 
-Special thanks to [`0xjohnny`](https://x.com/0xjohnny) for [FilzaSlop](https://github.com/0xjohnnydev/FilzaSlop) and the ContainerManager research used by 3105:
+Special thanks to [`0xjohnny`](https://x.com/0xjohnny) for [FilzaSlop](https://github.com/0xjohnnydev/FilzaSlop) and the related iOS security research:
 
-- [MobileHouseArrest identity-trust bug and MHA-C2 app-container access](https://github.com/0xjohnnydev/MobileHouseArrest-PoC#mobilehousearrest-request)
-- [MobileGestalt class-13 container-access bug](https://github.com/0xjohnnydev/MobileHouseArrest-PoC#mobilegestalt-class-13-request)
+- [MobileHouseArrest ContainerManager identity-trust bug](https://github.com/0xjohnnydev/MobileHouseArrest-PoC)
+- [`geod` MobileContainerManager `partDomain` traversal bug](https://github.com/0xjohnnydev/Geod-MCM-PoC)
+- [InstallCoordination persisted-state and final-symlink chain](https://github.com/0xjohnnydev/InstallCoordination-PoC)
+- [`cfprefsd` zero-file creation chain](https://github.com/0xjohnnydev/CFPrefsZeroFile-PoC)
 
 The project also builds on work from Pocket Poster/Nugget, CrazyMind90, forcequitOS, Dopamine, and their contributors. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for more attribution and upstream links.
 


### PR DESCRIPTION
## Summary

- Add direct README credit for [`0xjohnny`](https://x.com/0xjohnny).
- Link FilzaSlop and the MobileHouseArrest, Geod MCM, InstallCoordination, and CFPrefsZeroFile PoC repositories.

## Why

3105 already acknowledges FilzaSlop in its broader credits. This small README change makes the upstream research easier to find and gives users direct links to the relevant work. Clear, specific credit is standard open-source practice and helps the community trace technical lineage.

## Validation

- `git diff --check`
- Documentation-only change; no runtime behavior changed.
